### PR TITLE
Added Community Guidelines and Code of Conduct documents

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,10 +1,10 @@
 # Baton Rouge Slack Code of Conduct
 
-Our Code of Conduct is designed to make it clear that we believe in tolerance, respect, inclusion and hard work. Weâ€™ve built a tremendously impressive community of good people, and our goal is to continue growing along the same trajectory.
+Our Code of Conduct is designed to make it clear that we believe in tolerance, respect, inclusion and hard work. We've built a tremendously impressive community of good people, and our goal is to continue growing along the same trajectory.
 
 ## We strive to:
 
-1. **Be empathetic and respectful**: We work together to resolve conflict, assume good intentions and do our best to act in an empathetic fashion. We donâ€™t allow frustration to turn into a personal attack. A community where people feel uncomfortable or threatened is not a productive one. We expect community members to resolve disagreements constructively.
+1. **Be empathetic and respectful**: We work together to resolve conflict, assume good intentions and do our best to act in an empathetic fashion. We don't allow frustration to turn into a personal attack. A community where people feel uncomfortable or threatened is not a productive one. We expect community members to resolve disagreements constructively.
 2. **Take responsibility for our words and our actions**: We can all make mistakes; when we do, we take responsibility for them. If someone has been harmed or offended, we listen carefully and respectfully, and work to right the wrong.
 
 This code is not exhaustive or complete. It serves to distill our common understanding of a collaborative, shared environment and goals. We expect it to be followed in spirit as much as in the letter.
@@ -13,7 +13,7 @@ This code is not exhaustive or complete. It serves to distill our common underst
 
 We are committed to being a community that everyone feels good about joining. Although we may not be able to satisfy everyone, we will always work to treat everyone well.
 
-Weâ€™ll avoid a laundry list of all the things you may and may not be, what classes are legally protected, etc etc etc. Whoever you are, wherever youâ€™re from, whatever you look like or identify as, believe in or donâ€™t believe in, and so on and so forth, know that youâ€™re welcome.
+We'll avoid a laundry list of all the things you may and may not be, what classes are legally protected, etc etc etc. Whoever you are, wherever you're from, whatever you look like or identify as, believe in or don't believe in, and so on and so forth, know that you're welcome.
 
 ## Reporting Issues
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,28 @@
+# Baton Rouge Slack Code of Conduct
+
+Our Code of Conduct is designed to make it clear that we believe in tolerance, respect, inclusion and hard work. Weâ€™ve built a tremendously impressive community of good people, and our goal is to continue growing along the same trajectory.
+
+## We strive to:
+
+1. **Be empathetic and respectful**: We work together to resolve conflict, assume good intentions and do our best to act in an empathetic fashion. We donâ€™t allow frustration to turn into a personal attack. A community where people feel uncomfortable or threatened is not a productive one. We expect community members to resolve disagreements constructively.
+2. **Take responsibility for our words and our actions**: We can all make mistakes; when we do, we take responsibility for them. If someone has been harmed or offended, we listen carefully and respectfully, and work to right the wrong.
+
+This code is not exhaustive or complete. It serves to distill our common understanding of a collaborative, shared environment and goals. We expect it to be followed in spirit as much as in the letter.
+
+## Diversity: Everyone is welcome
+
+We are committed to being a community that everyone feels good about joining. Although we may not be able to satisfy everyone, we will always work to treat everyone well.
+
+Weâ€™ll avoid a laundry list of all the things you may and may not be, what classes are legally protected, etc etc etc. Whoever you are, wherever youâ€™re from, whatever you look like or identify as, believe in or donâ€™t believe in, and so on and so forth, know that youâ€™re welcome.
+
+## Reporting Issues
+
+If you notice any violations of this code of conduct, please send a direct message to Dylan Staley by typing `/msg @dstaley <your message>` into Slack, or by clicking the plus symbol next to "Direct Messages" in the Slack sidebar.
+
+## Source Material
+
+Portions of this Code of Conduct are taken from the following documents:
+
+1. [Ember Community Guidelines](http://emberjs.com/guidelines/)
+2. [Twitter Code of Conduct](https://github.com/twitter/code-of-conduct/blob/master/code-of-conduct.md)
+3. [Ubuntu Code of Conduct](http://www.ubuntu.com/about/about-ubuntu/conduct)

--- a/GUIDELINES.md
+++ b/GUIDELINES.md
@@ -1,0 +1,28 @@
+# Baton Rouge Slack Community Guidelines
+
+The Baton Rouge Slack community is a collection of people living in the Baton Rouge area who are, in some way, interested and/or involved with technology and design.
+
+## Our Community
+
+This community strives to be a welcoming, fun, informative, and beneficial community to Baton Rouge-area residents who have an interest in technology and design related topics. You don't need to be an experienced programmer or seasoned designer to take part, but you do need to live in the Baton Rouge area.
+
+## Joining and Invitations
+
+To request an invitation, please fill out the form on [brslack.com](https://brslack.com). If you're a member of the community who'd like to invite someone, please send them to the invite request form.
+
+## General Guidelines
+
+1. Conversations in the community are organized around topical channels. You are encouraged to conduct your conversations in the most appropriate channel. It's inevitable that a conversation may veer off-topic, and this is totally acceptable. However, if you find yourself too off-topic, please relocate your conversation to a more appropriate channel.
+2. Explicit material (including, but not limited to, pornographic images, discussions of sexual activity, or any other content that would be deemed NSFW) is not acceptable in any channel. Please remember that many participants are using Slack while in a work environment.
+
+## The #announcements Channel
+
+Due to the way Slack works, members cannot leave the #announcements channel. The following guidelines are designed to help keep the noise in this channel to a minimum, while still allowing important messages to reach everyone in the community.
+
+1. The #annoucements channel is not a channel for discussion. If you'd like to discuss a message posted in #announcements, please do so in the appropriate channel.
+2. All members are encouraged to create channels that they feel should exist. If you do, please let everyone know by posting a note in the #announcements channel.
+3. The #announcements channel is primarily used for announcements regarding the Baton Rouge Slack community, but can also be used to announce local events, news, and other things that members may be interested in. We ask that you use your best judgement when determining whether something is appropriate for #announcements.
+
+## Code of Conduct
+
+The Baton Rouge Slack community adheres to a standard of behavior. Please see our Code of Conduct for more information.


### PR DESCRIPTION
As we've reached over 100 members in the Baton Rouge Slack community, I wanted to add a formal statement of our guidelines and code of conduct.

`GUIDELINES.md` details the general guidelines by which the community operates. We've already been following these guidelines, with the exception of one guideline for the #announcements channel. Based on community feedback, I'd like to go ahead and open the channel up for announcements of local news, events, etc. that a large portion of our members can benefit from.

`CODE_OF_CONDUCT.md` is a better explanation of the standard of behavior we expect everyone to adhere to. We've been incredibly fortunate not to have any major violations of these rules, so I don't anticipate anyone having issues with them. They're based largely upon the work of the [Ember](http://emberjs.com/guidelines/), [Twitter](https://github.com/twitter/code-of-conduct/blob/master/code-of-conduct.md), and [Ubuntu](http://www.ubuntu.com/about/about-ubuntu/conduct) communities.

Since our community is just that, a community, I'd like to get feedback from members on both of these documents before merging them and putting them into effect. Please feel free to discuss on this PR or in the #meta channel in Slack.
